### PR TITLE
Remove hardcoded http protocol in url construction

### DIFF
--- a/src/docker/client.clj
+++ b/src/docker/client.clj
@@ -81,7 +81,6 @@
   (to-url [this path]
     (-> host
         (url version path)
-        (assoc :protocol "http")
         str))
   (to-ws-url [this path]
     (to-ws-url this path {}))


### PR DESCRIPTION
Protocol is being overwritten in the returned cemerick URL record type, which breaks https support.
